### PR TITLE
Build instructions for clarity

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,11 @@
 ## Ubuntu Linux 16.04 build instructions
 * install glslViewer (https://github.com/doug-moen/glslViewer)
 * apt-get install cmake libboost-all-dev libdouble-conversion-dev libreadline-dev
+* cd ~
+* git clone https://github.com/doug-moen/curv
+* cd curv
 * make
-* make install
+* sudo make install
 
 ## macOS build instructions
 * install homebrew (http://brew.sh)


### PR DESCRIPTION
`sudo make install`
instead of `make install`
else

```
Install the project...
-- Install configuration: "Debug"
-- Up-to-date: /usr/local/bin/curv
CMake Error at cmake_install.cmake:42 (file):
  file INSTALL cannot set permissions on "/usr/local/bin/curv"


Makefile:83: recipe for target 'install' failed


```