### PR TITLE
fix error of shared(string) to Atom

### DIFF
--- a/curv/evaluator.cc
+++ b/curv/evaluator.cc
@@ -444,7 +444,7 @@ struct_at(const Structure& ref, Value index, const Context& cx)
             (*result)[j++] = struct_at(ref, i, cx);
         return {result};
     }
-    Atom a = index.to<const String>(cx);
+    Atom a = index.to<const String>(cx).get();
     return ref.getfield(a, cx);
 }
 Value


### PR DESCRIPTION
Compiler error complaining about `index.to<const String>(cx)` returning a `Shared<string>` instead of something compatible with an Atom. I might have done it wrong but `get()` on the shared string seemed to have done the job and allowed compilation.

the compiler error:
```
/home/aodq/programming/curv/curv/evaluator.cc: In function ‘curv::Value curv::struct_at(const curv::Structure&, curv::Value, const curv::Context&)’:
/home/aodq/programming/curv/curv/evaluator.cc:447:36: error: conversion from ‘curv::Shared<const curv::String>’ to non-scalar type ‘curv::Atom’ requested
     Atom a = index.to<const String>(cx);
              ~~~~~~~~~~~~~~~~~~~~~~^~~~
make[4]: *** [CMakeFiles/libcurv.dir/build.make:231: CMakeFiles/libcurv.dir/curv/evaluator.cc.o] Error 1
```