### PR TITLE
Fix(?) link to README

### DIFF
--- a/docs/Tutorial.rst
+++ b/docs/Tutorial.rst
@@ -7,7 +7,7 @@ See `<../BUILD.md>`_.
 
 1. User Interface
 -----------------
-See `<docs/README.rst>`_.
+See `<README.rst>`_.
 
 2. Shapes
 ---------


### PR DESCRIPTION
This changes the "User Interface" section link (when viewed in a browser via <https://github.com/doug-moen/curv/blob/master/docs/Tutorial.rst>) from the incorrect (double "docs") form:

    https://github.com/doug-moen/curv/blob/master/docs/docs/README.rst

to the correct form:

    https://github.com/doug-moen/curv/blob/master/docs/README.rst

However I vaguely recall running into file path issues on GitHub with browser-viewing vs non-browser viewing and potentially differences between browsers on a previous occasion. So, if the link currently works for you, the solution is presumably more complex than just this change. :)