### PR TITLE
Fix 'if' does not guard errors in export_mesh.cc

### DIFF
--- a/cmd/export_mesh.cc
+++ b/cmd/export_mesh.cc
@@ -271,13 +271,19 @@ void export_mesh(Mesh_Format format, curv::Value value,
         for (unsigned int i=0; i<mesher.polygonPoolListSize(); ++i) {
             openvdb::tools::PolygonPool& pool = mesher.polygonPoolList()[i];
             for (unsigned int j=0; j<pool.numTriangles(); ++j) {
-                if (!first) out << " "; first = false;
+                if (!first) {
+                    out << " ";
+                    first = false;
+                }
                 auto& tri = pool.triangle(j);
                 out << tri[0] << " " << tri[2] << " " << tri[1] << " -1";
                 ++ntri;
             }
             for (unsigned int j=0; j<pool.numQuads(); ++j) {
-                if (!first) out << " "; first = false;
+                if (!first) {
+                    out << " ";
+                    first = false;
+                }
                 auto& q = pool.quad(j);
                 out << q[0] << " " << q[2] << " " << q[1] << " -1 "
                     << q[0] << " " << q[3] << " " << q[2] << " -1";
@@ -289,7 +295,10 @@ void export_mesh(Mesh_Format format, curv::Value value,
         "    <Coordinate point=\"";
         first = true;
         for (unsigned int i = 0; i < mesher.pointListSize(); ++i) {
-            if (!first) out << " "; first = false;
+            if (!first) {
+                out << " ";
+                first = false;
+            }
             auto& pt = mesher.pointList()[i];
             out << pt.x() << " " << pt.y() << " " << pt.z();
         }


### PR DESCRIPTION
I came across another error during compilation, however, I was able to make the following edits and resolve the issue.

I believe it may have occurred due to something in the C++ standard or whatever, and my compiler wanted brackets.

The original error I received was several of these:

```
/home/noah/curv/cmd/export_mesh.cc: In function ‘void export_mesh(Mesh_Format, curv::Value, curv::System&, const curv::Context&, const Export_Params&, std::ostream&)’:
/home/noah/curv/cmd/export_mesh.cc:274:17: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
                 if (!first) out << " "; first = false;
                 ^~
/home/noah/curv/cmd/export_mesh.cc:274:41: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
                 if (!first) out << " "; first = false;
                                         ^~~~~
```