### PR TITLE
Syntax Coloring in repl

### DIFF
--- a/curv/repl.cc
+++ b/curv/repl.cc
@@ -37,6 +37,7 @@ extern "C" {
 
 #include <libcurv/ansi_colour.h>
 #include <libcurv/context.h>
+#include <libcurv/exception.h>
 #include <libcurv/program.h>
 #include <libcurv/source.h>
 #include <libcurv/system.h>
@@ -53,6 +54,108 @@ void interrupt_handler(int)
     was_interrupted = true;
 }
 
+void color_input(std::string const& context, replxx::Replxx::colors_t& colors, void* user_data)
+{
+  auto* sys = static_cast<curv::System*>(user_data);
+
+  auto source = curv::make<curv::String_Source>("", context);
+
+  try {
+    curv::Scanner scanner{std::move(source), *sys};
+
+    for (;;) {
+      using Color = replxx::Replxx::Color;
+      using curv::Token;
+
+      Color col;
+      curv::Token tok = scanner.get_token();
+
+      switch (tok.kind_) {
+        case Token::k_end:
+          return;
+
+        // keywords
+        case Token::k_by:
+        case Token::k_do:
+        case Token::k_else:
+        case Token::k_for:
+        case Token::k_if:
+        case Token::k_in:
+        case Token::k_let:
+        case Token::k_include:
+        case Token::k_var:
+        case Token::k_where:
+        case Token::k_while:
+          col = Color::BRIGHTMAGENTA;
+          break;
+
+        // numerals
+        case Token::k_num:
+        case Token::k_hexnum:
+          col = Color::YELLOW;
+          break;
+
+        // string literal
+        case Token::k_quote:
+        case Token::k_string_segment:
+        case Token::k_char_escape:
+        case Token::k_apostrophe:
+        case Token::k_backtick:
+          col = Color::BRIGHTGREEN;
+          break;
+
+        // string interpolation
+        case Token::k_dollar_paren:
+        case Token::k_dollar_brace:
+        case Token::k_dollar_bracket:
+        case Token::k_dollar_ident:
+          col = Color::YELLOW;
+          break;
+
+        // syntactic symbols
+        case Token::k_semicolon:
+        case Token::k_equate:
+        case Token::k_assign:
+        case Token::k_ellipsis:
+        case Token::k_at:
+        case Token::k_right_arrow:
+          col = Color::BRIGHTRED;
+          break;
+
+        // operators
+        case Token::k_power:
+        case Token::k_plus:
+        case Token::k_minus:
+        case Token::k_times:
+        case Token::k_over:
+        case Token::k_range:
+        case Token::k_open_range:
+        case Token::k_equal:
+        case Token::k_not_equal:
+        case Token::k_less:
+        case Token::k_less_or_equal:
+        case Token::k_greater:
+        case Token::k_greater_or_equal:
+        case Token::k_not:
+        case Token::k_and:
+        case Token::k_or:
+        case Token::k_left_call:
+        case Token::k_right_call:
+          col = Color::BRIGHTBLUE;
+          break;
+
+        default:
+          col = Color::NORMAL;
+          break;
+      }
+
+      auto start = colors.begin();
+      std::fill(start + tok.first_, start + tok.last_, col);
+    }
+  } catch (curv::Exception&) {}
+}
+
+
 void repl(curv::System* sys)
 {
     // Catch keyboard interrupts, and set was_interrupted = true.
@@ -66,6 +169,7 @@ void repl(curv::System* sys)
     curv::Namespace names = sys->std_namespace();
 
     replxx::Replxx rx;
+    rx.set_highlighter_callback(color_input, static_cast<void*>(sys));
 
     for (;;) {
         was_interrupted = false;


### PR DESCRIPTION
Using `curv::Scanner`.

The colors and token groupings aren't final or well chosen at all - probably makes sense to leave a lot of "not very special" operators (`+ - * /`) unhighlighted to limit visual noise.

Using the scanner works pretty well, but has some limitations. For example in strings coloring embedded variables (`"asd $var bsd"`) works well, but for interpolation expressions only the leading escape-token is recognized:
![2018-10-08-172913_550x39_scrot](https://user-images.githubusercontent.com/1731279/46594575-afe14180-cb1f-11e8-9ce6-01f5a154a2f1.png)
